### PR TITLE
feat(user-management): add admin user management page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -28,6 +28,7 @@ export const routes: Routes = [
       { path: 'registry/key-plugin', component: PluginKeyComponent },
       { path: 'registry/licenseplate-plugin', component: PluginLicensePlateComponent },
       { path: 'settings', component: SettingsComponent },
+      { path: 'settings/users', loadComponent: () => import('./features/settings/user-management/user-management.component').then(m => m.UserManagementComponent) },
       { path: 'plugin-mews', component: PluginMewsComponent },
       { path: 'plugin-car-park', component: PluginLicensePlateComponent },
     ]

--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -13,6 +13,25 @@ export interface MeResponse {
   organization?: string;
 }
 
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  role: 'admin' | 'user' | 'guest';
+}
+
+export interface CreateUserRequest {
+  email: string;
+  name: string;
+  role: 'admin' | 'user' | 'guest';
+  password: string;
+}
+
+export interface UsersListResponse {
+  users: User[];
+  count: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class UsersService {
   private readonly API = `${environment.apiUrl}/api`;
@@ -25,5 +44,35 @@ export class UsersService {
 
   updateMe(payload: Partial<MeResponse>) {
     return this.http.patch<MeResponse>(`${this.API}/me`, payload);
+  }
+
+  // Admin endpoints - lijst van alle gebruikers
+  getAllUsers(): Observable<UsersListResponse> {
+    return this.http.get<UsersListResponse>(`${this.API}/admin/users`);
+  }
+
+  // Admin endpoints - maak nieuwe gebruiker aan
+  createUser(userData: CreateUserRequest): Observable<any> {
+    return this.http.post<any>(`${this.API}/admin/users`, userData);
+  }
+
+  // Admin endpoints - haal specifieke gebruiker op
+  getUser(id: string): Observable<any> {
+    return this.http.get<any>(`${this.API}/admin/users/${id}`);
+  }
+
+  // Admin endpoints - update gebruiker
+  updateUser(id: string, userData: { name: string; email: string }): Observable<any> {
+    return this.http.put<any>(`${this.API}/admin/users/${id}`, userData);
+  }
+
+  // Admin endpoints - update rol van gebruiker
+  updateUserRole(id: string, role: string): Observable<any> {
+    return this.http.put<any>(`${this.API}/admin/users/${id}/role`, { role });
+  }
+
+  // Admin endpoints - verwijder gebruiker
+  deleteUser(id: string): Observable<any> {
+    return this.http.delete<any>(`${this.API}/admin/users/${id}`);
   }
 }

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -2,6 +2,33 @@
 <div class="settings-container">
   <div class="sheet">
   <h1>Settings</h1>
+
+  <!-- Admin Section -->
+  <div class="settings-section">
+    <h2>Administration</h2>
+    <div class="settings-cards">
+      <mat-card class="settings-card" routerLink="/settings/users">
+        <mat-card-header>
+          <mat-icon class="card-icon">people</mat-icon>
+          <mat-card-title>User Management</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          Create, edit, and manage user accounts and roles
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-button color="primary">
+            Manage Users
+            <mat-icon>arrow_forward</mat-icon>
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  </div>
+
+  <!-- Hotel Settings Section -->
+  <div class="settings-section">
+    <h2>Hotel Information</h2>
+  
   <div class="settings-box">
     <label for="hotel-name">Hotelnaam</label>
     <input id="hotel-name" name="hotelName" type="text" class="settings-input" placeholder="Vul hotelnaam in" aria-label="Hotelnaam">
@@ -32,5 +59,6 @@
     </div>
   </div>
   <button mat-raised-button color="primary" class="save-button" aria-label="Instellingen opslaan">Opslaan</button>
+  </div>
 </div>
 </div>

--- a/src/app/features/settings/settings.component.scss
+++ b/src/app/features/settings/settings.component.scss
@@ -13,8 +13,68 @@
 }
 
 .settings-section {
+  margin-bottom: 32px;
+
+  h2 {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: #333;
+  }
+}
+
+.settings-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
   margin-bottom: 24px;
 }
+
+.settings-card {
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+  }
+
+  mat-card-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+
+    .card-icon {
+      font-size: 32px;
+      width: 32px;
+      height: 32px;
+      color: #2196F3;
+    }
+
+    mat-card-title {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+    }
+  }
+
+  mat-card-content {
+    color: #666;
+    font-size: 14px;
+  }
+
+  mat-card-actions {
+    padding: 0 16px 16px;
+
+    button {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+  }
+}
+
 .settings-box {
   padding: 16px;
   border: 1px solid #e0e0e0;

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -1,7 +1,13 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-settings',
+  standalone: true,
+  imports: [RouterModule, MatButtonModule, MatCardModule, MatIconModule],
   templateUrl: './settings.component.html',
   styleUrl: './settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/features/settings/user-management/user-management.component.html
+++ b/src/app/features/settings/user-management/user-management.component.html
@@ -1,0 +1,152 @@
+<div class="user-management-container">
+  <mat-card class="create-user-card">
+    <mat-card-header>
+      <mat-card-title>
+        <mat-icon>person_add</mat-icon>
+        Create New User
+      </mat-card-title>
+      <mat-card-subtitle>
+        Create a new user account. They will receive instructions to set their password via email.
+      </mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <form [formGroup]="userForm" (ngSubmit)="onSubmit()">
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" placeholder="John Doe">
+            <mat-icon matPrefix>person</mat-icon>
+            <mat-error *ngIf="userForm.get('name')?.hasError('required')">
+              Name is required
+            </mat-error>
+            <mat-error *ngIf="userForm.get('name')?.hasError('minlength')">
+              Name must be at least 2 characters
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Email</mat-label>
+            <input matInput formControlName="email" type="email" placeholder="user@example.com">
+            <mat-icon matPrefix>email</mat-icon>
+            <mat-error *ngIf="userForm.get('email')?.hasError('required')">
+              Email is required
+            </mat-error>
+            <mat-error *ngIf="userForm.get('email')?.hasError('email')">
+              Please enter a valid email
+            </mat-error>
+          </mat-form-field>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Role</mat-label>
+            <mat-select formControlName="role">
+              <mat-option *ngFor="let role of roles" [value]="role.value">
+                {{ role.label }}
+              </mat-option>
+            </mat-select>
+            <mat-icon matPrefix>admin_panel_settings</mat-icon>
+            <mat-error *ngIf="userForm.get('role')?.hasError('required')">
+              Role is required
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Temporary Password</mat-label>
+            <input matInput formControlName="password" type="password" placeholder="Min 6 characters">
+            <mat-icon matPrefix>lock</mat-icon>
+            <mat-error *ngIf="userForm.get('password')?.hasError('required')">
+              Password is required
+            </mat-error>
+            <mat-error *ngIf="userForm.get('password')?.hasError('minlength')">
+              Password must be at least 6 characters
+            </mat-error>
+            <mat-hint>User can change this via "Forgot Password"</mat-hint>
+          </mat-form-field>
+        </div>
+
+        <div class="form-actions">
+          <button mat-raised-button color="primary" type="submit" [disabled]="userForm.invalid || submitting()">
+            <mat-spinner diameter="20" *ngIf="submitting()"></mat-spinner>
+            <span *ngIf="!submitting()">
+              <mat-icon>add</mat-icon>
+              Create User
+            </span>
+          </button>
+        </div>
+      </form>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card class="users-list-card">
+    <mat-card-header>
+      <mat-card-title>
+        <mat-icon>people</mat-icon>
+        Users
+      </mat-card-title>
+      <mat-card-subtitle>
+        Manage existing users
+      </mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <div *ngIf="loading()" class="loading-container">
+        <mat-spinner></mat-spinner>
+      </div>
+
+      <div *ngIf="!loading()" class="table-container">
+        <table mat-table [dataSource]="users()" class="users-table">
+          <!-- Name Column -->
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let user">
+              <div class="user-info">
+                <mat-icon class="user-icon">person</mat-icon>
+                {{ user.name }}
+              </div>
+            </td>
+          </ng-container>
+
+          <!-- Email Column -->
+          <ng-container matColumnDef="email">
+            <th mat-header-cell *matHeaderCellDef>Email</th>
+            <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+          </ng-container>
+
+          <!-- Role Column -->
+          <ng-container matColumnDef="role">
+            <th mat-header-cell *matHeaderCellDef>Role</th>
+            <td mat-cell *matCellDef="let user">
+              <mat-form-field appearance="outline" class="role-select">
+                <mat-select [value]="user.role" (selectionChange)="updateRole(user, $event.value)">
+                  <mat-option *ngFor="let role of roles" [value]="role.value">
+                    {{ role.label }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </td>
+          </ng-container>
+
+          <!-- Actions Column -->
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>Actions</th>
+            <td mat-cell *matCellDef="let user">
+              <button mat-icon-button color="warn" (click)="deleteUser(user)" matTooltip="Delete user">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+
+        <div *ngIf="users().length === 0" class="no-users">
+          <mat-icon>people_outline</mat-icon>
+          <p>No users found</p>
+        </div>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/features/settings/user-management/user-management.component.html
+++ b/src/app/features/settings/user-management/user-management.component.html
@@ -15,7 +15,7 @@
         <div class="form-row">
           <mat-form-field appearance="outline" class="full-width">
             <mat-label>Name</mat-label>
-            <input matInput formControlName="name" placeholder="John Doe">
+            <input matInput formControlName="name" placeholder="">
             <mat-icon matPrefix>person</mat-icon>
             <mat-error *ngIf="userForm.get('name')?.hasError('required')">
               Name is required

--- a/src/app/features/settings/user-management/user-management.component.scss
+++ b/src/app/features/settings/user-management/user-management.component.scss
@@ -1,0 +1,128 @@
+.user-management-container {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.create-user-card,
+.users-list-card {
+  margin-bottom: 24px;
+}
+
+mat-card-header {
+  margin-bottom: 16px;
+
+  mat-card-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 24px;
+
+    mat-icon {
+      font-size: 28px;
+      width: 28px;
+      height: 28px;
+    }
+  }
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+
+  button {
+    min-width: 140px;
+    height: 48px;
+
+    mat-spinner {
+      display: inline-block;
+      margin: 0 auto;
+    }
+
+    span {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  }
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px 0;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.users-table {
+  width: 100%;
+  
+  th {
+    font-weight: 600;
+    font-size: 14px;
+    padding: 16px 12px;
+  }
+
+  td {
+    padding: 12px;
+  }
+
+  .user-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .user-icon {
+      color: rgba(0, 0, 0, 0.54);
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .role-select {
+    margin: 0;
+    
+    ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+      display: none;
+    }
+  }
+}
+
+.no-users {
+  text-align: center;
+  padding: 48px 24px;
+  color: rgba(0, 0, 0, 0.54);
+
+  mat-icon {
+    font-size: 64px;
+    width: 64px;
+    height: 64px;
+    margin-bottom: 16px;
+  }
+
+  p {
+    font-size: 16px;
+    margin: 0;
+  }
+}

--- a/src/app/features/settings/user-management/user-management.component.ts
+++ b/src/app/features/settings/user-management/user-management.component.ts
@@ -1,0 +1,126 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatSelectModule } from '@angular/material/select';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { UsersService, User, CreateUserRequest } from '../../../core/services/users.service';
+
+@Component({
+  selector: 'app-user-management',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTableModule,
+    MatSelectModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+    MatDialogModule
+  ],
+  templateUrl: './user-management.component.html',
+  styleUrl: './user-management.component.scss'
+})
+export class UserManagementComponent implements OnInit {
+  userForm: FormGroup;
+  users = signal<User[]>([]);
+  loading = signal(false);
+  submitting = signal(false);
+  displayedColumns: string[] = ['name', 'email', 'role', 'actions'];
+
+  roles = [
+    { value: 'admin', label: 'Administrator' },
+    { value: 'user', label: 'User' },
+    { value: 'guest', label: 'Guest' }
+  ];
+
+  constructor(
+    private fb: FormBuilder,
+    private usersService: UsersService,
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
+  ) {
+    this.userForm = this.fb.group({
+      name: ['', [Validators.required, Validators.minLength(2)]],
+      email: ['', [Validators.required, Validators.email]],
+      role: ['user', [Validators.required]],
+      password: ['', [Validators.required, Validators.minLength(6)]]
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  loadUsers(): void {
+    this.loading.set(true);
+    this.usersService.getAllUsers().subscribe({
+      next: (response: any) => {
+        this.users.set(response.users);
+        this.loading.set(false);
+      },
+      error: (err: any) => {
+        this.snackBar.open(err.error?.error || 'Failed to load users', 'Close', { duration: 3000 });
+        this.loading.set(false);
+      }
+    });
+  }
+
+  onSubmit(): void {
+    if (this.userForm.valid) {
+      this.submitting.set(true);
+      const userData: CreateUserRequest = this.userForm.value;
+
+      this.usersService.createUser(userData).subscribe({
+        next: (response: any) => {
+          this.snackBar.open('User created successfully! They can set their password via "Forgot Password".', 'Close', { duration: 5000 });
+          this.userForm.reset({ role: 'user' });
+          this.loadUsers();
+          this.submitting.set(false);
+        },
+        error: (err: any) => {
+          this.snackBar.open(err.error?.error || 'Failed to create user', 'Close', { duration: 3000 });
+          this.submitting.set(false);
+        }
+      });
+    }
+  }
+
+  deleteUser(user: User): void {
+    if (confirm(`Are you sure you want to delete user "${user.name}"?`)) {
+      this.usersService.deleteUser(user.id).subscribe({
+        next: () => {
+          this.snackBar.open('User deleted successfully', 'Close', { duration: 3000 });
+          this.loadUsers();
+        },
+        error: (err: any) => {
+          this.snackBar.open(err.error?.error || 'Failed to delete user', 'Close', { duration: 3000 });
+        }
+      });
+    }
+  }
+
+  updateRole(user: User, newRole: string): void {
+    this.usersService.updateUserRole(user.id, newRole).subscribe({
+      next: () => {
+        this.snackBar.open('User role updated successfully', 'Close', { duration: 3000 });
+        this.loadUsers();
+      },
+      error: (err: any) => {
+        this.snackBar.open(err.error?.error || 'Failed to update role', 'Close', { duration: 3000 });
+      }
+    });
+  }
+}

--- a/src/app/shared/sidebar/sidebar.component.html
+++ b/src/app/shared/sidebar/sidebar.component.html
@@ -65,7 +65,7 @@
     </mat-toolbar>
     <!-- Your main content goes here -->
     <div class="content">
-      <ng-content></ng-content>
+      <router-outlet></router-outlet>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>


### PR DESCRIPTION
- Add user management component with create, list, update role, and delete functionality
- Extend UsersService with admin endpoints (getAllUsers, createUser, updateUserRole, deleteUser)
- Add user management route at /settings/users
- Update settings page with navigation card to user management
- Users can be created with email, name, role, and temp password
- New users can set their own password via forgot password feature
- Fix sidebar to use router-outlet instead of ng-content for proper routing
<img width="1435" height="795" alt="image_2026-01-05_080659194" src="https://github.com/user-attachments/assets/ed95b9a4-43aa-4706-94a0-c74ef1322893" />
